### PR TITLE
Fix for sending edit notifications

### DIFF
--- a/EditNotify.hooks.php
+++ b/EditNotify.hooks.php
@@ -881,14 +881,14 @@ class EditNotifyHooks {
 				if ( $handleAllPagesAlert ) {
 					$handleAllPages = false;
 
-					if ( ( array_key_exists( 'template', $allPagesAlert ) && array_key_exists( 'templateField', $allPagesAlert ) ) == false ) {
+					if ( ( array_key_exists( 'template', $allPagesAlert ) === false && array_key_exists( 'templateField', $allPagesAlert ) ) == false ) {
 						$handleAllPages = true;
 					}
 
 					//Check for the namespace and get users from the array
 					if ( $handleAllPages ) {
 
-						if (  array_key_exists( 'namespace', $allPagesAlert ) == false  && array_key_exists( 'category', $allPagesAlert )  == false ) {
+						if (  array_key_exists( 'namespace', $allPagesAlert ) || array_key_exists( 'category', $allPagesAlert ) ) {
 							foreach ( $allPagesAlert['users'] as $allPagesUsername ) {
 								$allPagesUserArray[] = $allPagesUsername;
 							}


### PR DESCRIPTION
Not sure what the intention was, but all the code point to that, that
edit notifications for namespace and categories would be ignored

ERM: #11264