### PR TITLE
Fix VE saving error

### DIFF
--- a/EditNotify.hooks.php
+++ b/EditNotify.hooks.php
@@ -802,7 +802,7 @@ class EditNotifyHooks {
 			}
 
 			if ( $categories ) {
-				foreach ( $categories as $category => $title) {
+				foreach ( $categories as $category => $catTitle) {
 					$categoryUserArray = array();
 					foreach ( $wgEditNotifyAlerts as $categoryAlert ) {
 						$handleCategoryAlert = false;


### PR DESCRIPTION
Iterating over categories overrode the $title which is a Title object,
resulting in wrong title being sent to Echo

Problem introduced in https://github.com/hallowelt/mediawiki-extensions-EditNotify/commit/41580fceedc1688bd2b4aac34b565d45621f98c4